### PR TITLE
Add textbox for the grabbed links and encode links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 node_modules/
+.DS_Store
+package-lock.json

--- a/dist/grabber.user.js
+++ b/dist/grabber.user.js
@@ -309,7 +309,7 @@ var metadata = {
 var servers = document.getElementById('servers');
 var statusContainer = document.createElement('div');
 statusContainer.classList.add('grabber__notification');
-statusContainer.innerHTML = '<span>Grabber \u2605</span>\n  <span>Quality:</span>\n  <select id="grabber__quality">\n      <option value="360p">360p</option>\n      <option value="480p">480p</option>\n      <option value="720p">720p</option>\n      <option value="1080p">1080p</option>\n  </select>\n  \u2713\n  <span>Status:</span>\n  <div id="grabber__status">ready! Press Grab All to start.</div>';
+statusContainer.innerHTML = '<span>Grabber \u2605</span>\n  <span>Quality:</span>\n  <select id="grabber__quality">\n      <option value="360p">360p</option>\n      <option value="480p">480p</option>\n      <option value="720p">720p</option>\n      <option value="1080p">1080p</option>\n  </select>\n  \u2713\n  <span>Status:</span>\n  <div id="grabber__status">ready! Press Grab All to start.</div>\n  <textarea id="grabbed__links"></textarea>';
 servers.insertBefore(statusContainer, servers.firstChild);
 
 /**
@@ -318,6 +318,11 @@ servers.insertBefore(statusContainer, servers.firstChild);
  */
 function status(message) {
   document.getElementById('grabber__status').innerHTML = message;
+}
+
+function setLinks(links) {
+  document.getElementById('grabbed__links').style.display = 'block';
+  document.getElementById('grabbed__links').value = links;
 }
 
 // Disable inputs when grabbing begins.
@@ -375,7 +380,8 @@ function requeue() {
     clearTimeout(window.dlTimeout);
     dlInProgress = false;
     enableInputs(); /* Enable the buttons and quality select */
-    status('All done. The completed links are copied to your clipboard.');
+    status('All done. The completed links are in the box below and also copied to your clipboard.');
+    setLinks(dlAggregateLinks);
     GM_setClipboard(dlAggregateLinks);
   }
 }
@@ -691,7 +697,7 @@ Object.defineProperty(exports, "__esModule", {
 exports.default = applyStyle;
 /* global GM_addStyle */
 
-var styles = "\n  #grabber__metadata-link {\n      margin-left: 5px;\n  }\n  .grabber--fail {\n      color: indianred;\n  }\n  .grabber__btn {\n      border: 1px solid #555;\n      border-radius: 2px;\n      background-color: #16151c;\n      color: #888;\n      padding: 1px 5px 1px 5px;\n      margin-top: 5px;\n  }\n  .grabber__btn:hover {\n      background-color: #111111;\n  }\n  .grabber__btn:active {\n      background-color: #151515;\n  }\n\n  .grabber__btn:disabled {\n      color: #888;\n      background-color: #222;\n  }\n\n  .grabber__notification {\n      padding: 0 10px;\n      margin-bottom: 10px;\n      color: #888;\n  }\n  .grabber__notification > span {\n      display: inline-block;\n      font-weight: 500;\n  }\n  .grabber__notification > #grabber__status {\n      margin-left: 5px;\n      display: inline-block;\n      color: #888;\n  }\n  #grabber__quality {\n      background: inherit;\n      border-radius: 2px;\n      color: #888;\n      border: 1px solid #555;\n  }\n\n  #grabber__quality:disabled {\n      background: #222;\n      color: #888;\n  }\n\n  #grabber__quality > option {\n      background: #16151c;\n  }\n  ";
+var styles = "\n  #grabber__metadata-link {\n      margin-left: 5px;\n  }\n  .grabber--fail {\n      color: indianred;\n  }\n  .grabber__btn {\n      border: 1px solid #555;\n      border-radius: 2px;\n      background-color: #16151c;\n      color: #888;\n      padding: 1px 5px 1px 5px;\n      margin-top: 5px;\n  }\n  .grabber__btn:hover {\n      background-color: #111111;\n  }\n  .grabber__btn:active {\n      background-color: #151515;\n  }\n\n  .grabber__btn:disabled {\n      color: #888;\n      background-color: #222;\n  }\n\n  .grabber__notification {\n      padding: 0 10px;\n      margin-bottom: 10px;\n      color: #888;\n  }\n  .grabber__notification > span {\n      display: inline-block;\n      font-weight: 500;\n  }\n  .grabber__notification > #grabber__status {\n      margin-left: 5px;\n      display: inline-block;\n      color: #888;\n  }\n  #grabber__quality {\n      background: inherit;\n      border-radius: 2px;\n      color: #888;\n      border: 1px solid #555;\n  }\n\n  #grabbed__links {\n     display: none;\n     width: 100%;\n     height: 200px;\n     background: #0f0e13;\n     color: #9a9a9a;\n     border: none;\n     margin: 10px 0;\n     padding: 10px;\n  }\n\n  #grabber__quality:disabled {\n      background: #222;\n      color: #888;\n  }\n\n  #grabber__quality > option {\n      background: #16151c;\n  }\n  ";
 function applyStyle() {
     GM_addStyle(styles);
 }

--- a/dist/grabber.user.js
+++ b/dist/grabber.user.js
@@ -406,7 +406,7 @@ function processGrabber() {
     switch (dlServerType) {
       case 'RapidVideo':
         api.videoLinksRV(resp['target']).then(function (resp) {
-          dlAggregateLinks += resp[0]['file'] + '\n';
+          dlAggregateLinks += encodeURI(resp[0]['file']) + '\n';
           var fileSafeName = utils.fileSafeString(animeName + '-ep_' + ep.num + '-' + resp[0]['label'] + '.mp4');
           // Metadata only for RapidVideo
           metadata.files.push({
@@ -441,7 +441,7 @@ function processGrabber() {
             // preferred quality is not present it wont grab any.
             if (data[i]['label'] === dlQuality) {
               var title = utils.fileSafeString(animeName + '-ep_' + ep.num + '-' + data[i]['label']);
-              dlAggregateLinks += data[i]['file'] + '?&title=' + title + '&type=video/' + data[i]['type'] + '\n';
+              dlAggregateLinks += encodeURI(data[i]['file'] + '?&title=' + title + '&type=video/' + data[i]['type']) + '\n';
             }
           }
           status('Completed ' + ep.num);

--- a/dist/grabber.user.js
+++ b/dist/grabber.user.js
@@ -309,7 +309,7 @@ var metadata = {
 var servers = document.getElementById('servers');
 var statusContainer = document.createElement('div');
 statusContainer.classList.add('grabber__notification');
-statusContainer.innerHTML = '<span>Grabber \u2605</span>\n  <span>Quality:</span>\n  <select id="grabber__quality">\n      <option value="360p">360p</option>\n      <option value="480p">480p</option>\n      <option value="720p">720p</option>\n      <option value="1080p">1080p</option>\n  </select>\n  \u2713\n  <span>Status:</span>\n  <div id="grabber__status">ready! Press Grab All to start.</div>\n  <textarea id="grabbed__links"></textarea>';
+statusContainer.innerHTML = '<span>Grabber \u2605</span>\n  <span>Quality:</span>\n  <select id="grabber__quality">\n      <option value="360p">360p</option>\n      <option value="480p">480p</option>\n      <option value="720p">720p</option>\n      <option value="1080p">1080p</option>\n  </select>\n  \u2713\n  <span>Status:</span>\n  <div id="grabber__status">ready! Press Grab All to start.</div>\n  <button class="btn btn-sm btn-primary" id="hide__box">Hide links box</button>\n  <textarea id="grabbed__links"></textarea>';
 servers.insertBefore(statusContainer, servers.firstChild);
 
 /**
@@ -322,7 +322,12 @@ function status(message) {
 
 function setLinks(links) {
   document.getElementById('grabbed__links').style.display = 'block';
+  document.getElementById('hide__box').style.display = 'block';
   document.getElementById('grabbed__links').value = links;
+  document.getElementById('hide__box').addEventListener('click', function () {
+    document.getElementById('grabbed__links').style.display = 'none';
+    document.getElementById('hide__box').style.display = 'none';
+  });
 }
 
 // Disable inputs when grabbing begins.
@@ -697,7 +702,7 @@ Object.defineProperty(exports, "__esModule", {
 exports.default = applyStyle;
 /* global GM_addStyle */
 
-var styles = "\n  #grabber__metadata-link {\n      margin-left: 5px;\n  }\n  .grabber--fail {\n      color: indianred;\n  }\n  .grabber__btn {\n      border: 1px solid #555;\n      border-radius: 2px;\n      background-color: #16151c;\n      color: #888;\n      padding: 1px 5px 1px 5px;\n      margin-top: 5px;\n  }\n  .grabber__btn:hover {\n      background-color: #111111;\n  }\n  .grabber__btn:active {\n      background-color: #151515;\n  }\n\n  .grabber__btn:disabled {\n      color: #888;\n      background-color: #222;\n  }\n\n  .grabber__notification {\n      padding: 0 10px;\n      margin-bottom: 10px;\n      color: #888;\n  }\n  .grabber__notification > span {\n      display: inline-block;\n      font-weight: 500;\n  }\n  .grabber__notification > #grabber__status {\n      margin-left: 5px;\n      display: inline-block;\n      color: #888;\n  }\n  #grabber__quality {\n      background: inherit;\n      border-radius: 2px;\n      color: #888;\n      border: 1px solid #555;\n  }\n\n  #grabbed__links {\n     display: none;\n     width: 100%;\n     height: 200px;\n     background: #0f0e13;\n     color: #9a9a9a;\n     border: none;\n     margin: 10px 0;\n     padding: 10px;\n  }\n\n  #grabber__quality:disabled {\n      background: #222;\n      color: #888;\n  }\n\n  #grabber__quality > option {\n      background: #16151c;\n  }\n  ";
+var styles = "\n  #grabber__metadata-link {\n      margin-left: 5px;\n  }\n  .grabber--fail {\n      color: indianred;\n  }\n  .grabber__btn {\n      border: 1px solid #555;\n      border-radius: 2px;\n      background-color: #16151c;\n      color: #888;\n      padding: 1px 5px 1px 5px;\n      margin-top: 5px;\n  }\n  .grabber__btn:hover {\n      background-color: #111111;\n  }\n  .grabber__btn:active {\n      background-color: #151515;\n  }\n\n  .grabber__btn:disabled {\n      color: #888;\n      background-color: #222;\n  }\n\n  .grabber__notification {\n      padding: 0 10px;\n      margin-bottom: 10px;\n      color: #888;\n  }\n  .grabber__notification > span {\n      display: inline-block;\n      font-weight: 500;\n  }\n  .grabber__notification > #grabber__status {\n      margin-left: 5px;\n      display: inline-block;\n      color: #888;\n  }\n  #grabber__quality {\n      background: inherit;\n      border-radius: 2px;\n      color: #888;\n      border: 1px solid #555;\n  }\n\n  #hide__box {\n      display: none;\n  }\n\n  #grabbed__links {\n     display: none;\n     width: 100%;\n     height: 200px;\n     background: #0f0e13;\n     color: #9a9a9a;\n     border: none;\n     margin: 10px 0;\n     padding: 10px;\n  }\n\n  #grabber__quality:disabled {\n      background: #222;\n      color: #888;\n  }\n\n  #grabber__quality > option {\n      background: #16151c;\n  }\n  ";
 function applyStyle() {
     GM_addStyle(styles);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ statusContainer.innerHTML =
   ✓
   <span>Status:</span>
   <div id="grabber__status">ready! Press Grab All to start.</div>
+  <button class="btn btn-sm btn-primary" id="hide__box">Hide links box</button>
   <textarea id="grabbed__links"></textarea>`
 servers.insertBefore(statusContainer, servers.firstChild)
 
@@ -60,7 +61,12 @@ function status (message) {
 
 function setLinks (links) {
   document.getElementById('grabbed__links').style.display = 'block'
+  document.getElementById('hide__box').style.display = 'block'
   document.getElementById('grabbed__links').value = links
+  document.getElementById('hide__box').addEventListener('click', function() {
+    document.getElementById('grabbed__links').style.display = 'none'
+    document.getElementById('hide__box').style.display = 'none'
+  })
 }
 
 // Disable inputs when grabbing begins.

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ function setLinks (links) {
   document.getElementById('grabbed__links').style.display = 'block'
   document.getElementById('hide__box').style.display = 'block'
   document.getElementById('grabbed__links').value = links
-  document.getElementById('hide__box').addEventListener('click', function() {
+  document.getElementById('hide__box').addEventListener('click', () => {
     document.getElementById('grabbed__links').style.display = 'none'
     document.getElementById('hide__box').style.display = 'none'
   })

--- a/src/index.js
+++ b/src/index.js
@@ -183,7 +183,7 @@ function processGrabber () {
                 // preferred quality is not present it wont grab any.
                 if (data[i]['label'] === dlQuality) {
                   let title = utils.fileSafeString(`${animeName}-ep_${ep.num}-${data[i]['label']}`)
-                  dlAggregateLinks += encodeURI(`${data[i]['file']}?&title=${title}&type=video/${data[i]['type']}`)+`\n`
+                  dlAggregateLinks += encodeURI(`${data[i]['file']}?&title=${title}&type=video/${data[i]['type']}`) + `\n`
                 }
               }
               status('Completed ' + ep.num)

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,8 @@ statusContainer.innerHTML =
   </select>
   ✓
   <span>Status:</span>
-  <div id="grabber__status">ready! Press Grab All to start.</div>`
+  <div id="grabber__status">ready! Press Grab All to start.</div>
+  <textarea id="grabbed__links"></textarea>`
 servers.insertBefore(statusContainer, servers.firstChild)
 
 /**
@@ -55,6 +56,11 @@ servers.insertBefore(statusContainer, servers.firstChild)
  */
 function status (message) {
   document.getElementById('grabber__status').innerHTML = message
+}
+
+function setLinks (links) {
+  document.getElementById('grabbed__links').style.display = 'block'
+  document.getElementById('grabbed__links').value = links
 }
 
 // Disable inputs when grabbing begins.
@@ -112,7 +118,8 @@ function requeue () {
     clearTimeout(window.dlTimeout)
     dlInProgress = false
     enableInputs() /* Enable the buttons and quality select */
-    status('All done. The completed links are copied to your clipboard.')
+    status('All done. The completed links are in the box below and also copied to your clipboard.')
+    setLinks(dlAggregateLinks)
     GM_setClipboard(dlAggregateLinks)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ function processGrabber () {
         case 'RapidVideo':
           api.videoLinksRV(resp['target'])
             .then(resp => {
-              dlAggregateLinks += resp[0]['file'] + '\n'
+              dlAggregateLinks += encodeURI(resp[0]['file']) + '\n'
               let fileSafeName = utils.fileSafeString(`${animeName}-ep_${ep.num}-${resp[0]['label']}.mp4`)
               // Metadata only for RapidVideo
               metadata.files.push({
@@ -183,7 +183,7 @@ function processGrabber () {
                 // preferred quality is not present it wont grab any.
                 if (data[i]['label'] === dlQuality) {
                   let title = utils.fileSafeString(`${animeName}-ep_${ep.num}-${data[i]['label']}`)
-                  dlAggregateLinks += `${data[i]['file']}?&title=${title}&type=video/${data[i]['type']}\n`
+                  dlAggregateLinks += encodeURI(`${data[i]['file']}?&title=${title}&type=video/${data[i]['type']}`)+`\n`
                 }
               }
               status('Completed ' + ep.num)

--- a/src/style.js
+++ b/src/style.js
@@ -49,6 +49,17 @@ let styles =
       border: 1px solid #555;
   }
 
+  #grabbed__links {
+     display: none;
+     width: 100%;
+     height: 200px;
+     background: #0f0e13;
+     color: #9a9a9a;
+     border: none;
+     margin: 10px 0;
+     padding: 10px;
+  }
+
   #grabber__quality:disabled {
       background: #222;
       color: #888;

--- a/src/style.js
+++ b/src/style.js
@@ -49,6 +49,10 @@ let styles =
       border: 1px solid #555;
   }
 
+  #hide__box {
+      display: none;
+  }
+
   #grabbed__links {
      display: none;
      width: 100%;


### PR DESCRIPTION
Added a textbox below the status text so that the user can still copy the grabbed links even if he overrides the clipboard. Should be the the fix for #8

Encoded the grabbed links, otherwise it fails to be recognized as links for some animes such as **TOKYO GHOUL √A**. Now they should work fine for anime with special characters in their names.

